### PR TITLE
fix : 로그인 시 세션을 생성하고, 로그아웃 시 세션을 삭제하도록 수정

### DIFF
--- a/src/data/integrations/passport/initPassport.ts
+++ b/src/data/integrations/passport/initPassport.ts
@@ -1,4 +1,6 @@
 import passport from 'passport';
+import session from 'express-session';
+import { Express } from 'express';
 import configureGooglePassport from './googleOAuth';
 import configuresNaverPassport from './naverOAuth';
 import configuresKakaoPassport from './kakaoOAuth';
@@ -6,7 +8,19 @@ import { userDataLocalRepository } from '../../repositoryImpls/localUserReposito
 
 const userRepository = userDataLocalRepository();
 
-function initPassport() {
+function initPassport(app: Express) {
+  app.use(
+    session({
+      secret: process.env.SESSION_SECRET || 'your-secrest-key',
+      resave: false,
+      saveUninitialized: true,
+      rolling: true,
+      cookie: {
+        maxAge: 1000 * 60 * 60 * 24, // 1일
+        secure: process.env.NODE_ENV === 'production',
+      },
+    }),
+  );
   configureGooglePassport(passport, userRepository);
   configuresNaverPassport(passport, userRepository);
   configuresKakaoPassport(passport, userRepository);

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ app.use(
   }),
 );
 
-initPassport();
+initPassport(app);
 app.use(passport.initialize());
 app.use(passport.session());
 

--- a/src/presentation/controllers/userController.ts
+++ b/src/presentation/controllers/userController.ts
@@ -243,17 +243,13 @@ export const logout = (req: Request, res: Response) => {
           message: '로그아웃 처리 중 오류가 발생했습니다.',
         });
       }
-
-      res.clearCookie('connect.sid');
-      res.status(200).json({
-        success: true,
-        message: '로그아웃이 성공적으로 완료되었습니다.',
+      req.logout(() => {
+        res.clearCookie('connect.sid');
+        res.status(200).json({
+          success: true,
+          message: '로그아웃이 성공적으로 완료되었습니다.',
+        });
       });
-    });
-  } else {
-    res.status(200).json({
-      success: true,
-      message: '로그아웃이 성공적으로 완료되었습니다.',
     });
   }
 };

--- a/src/presentation/routers/auth/googleRouter.ts
+++ b/src/presentation/routers/auth/googleRouter.ts
@@ -20,26 +20,33 @@ googleRouter.get(
   '/callback',
   passport.authenticate('google', { failureRedirect: '/' }),
   (req, res) => {
-    const user = req.user as User;
-    const redirectUrlBase =
-      process.env.REDIRECT_URL_BASE || 'http://localhost:5173';
+    req.session.regenerate((err) => {
+      if (err) {
+        console.error('세션 복구 오류:', err);
+        return res.redirect('/');
+      }
 
-    console.log('Callback - 유저 정보:', user);
-    console.log('Callback - REDIRECT_URL_BASE:', redirectUrlBase);
+      const user = req.user as User;
+      const redirectUrlBase =
+        process.env.REDIRECT_URL_BASE || 'http://localhost:5173';
 
-    if (user) {
-      const redirectUrl = `${redirectUrlBase}/login?token=${user.access_token}&user=${encodeURIComponent(
-        JSON.stringify(user),
-      )}`;
+      console.log('Callback - 유저 정보:', user);
+      console.log('Callback - REDIRECT_URL_BASE:', redirectUrlBase);
 
-      // 최종 리다이렉트 URL 확인
-      console.log('마지막 redirect URL:', redirectUrl);
+      if (user) {
+        const redirectUrl = `${redirectUrlBase}/login?token=${user.access_token}&user=${encodeURIComponent(
+          JSON.stringify(user),
+        )}`;
 
-      res.redirect(redirectUrl);
-    } else {
-      console.log('User object is null or undefined');
-      res.redirect('/');
-    }
+        // 최종 리다이렉트 URL 확인
+        console.log('마지막 redirect URL:', redirectUrl);
+
+        res.redirect(redirectUrl);
+      } else {
+        console.log('User object is null or undefined');
+        res.redirect('/');
+      }
+    });
   },
 );
 

--- a/src/presentation/routers/auth/kakaoRouter.ts
+++ b/src/presentation/routers/auth/kakaoRouter.ts
@@ -24,21 +24,27 @@ kakaoRouter.get(
   '/callback',
   passport.authenticate('kakao', { failureRedirect: '/' }),
   (req, res) => {
-    const user = req.user as User;
-    const redirectUrlBase =
-      process.env.REDIRECT_URL_BASE || 'http://localhost:5173';
+    req.session.regenerate((err) => {
+      if (err) {
+        console.error('세션 복구 오류:', err);
+        return res.redirect('/');
+      }
+      const user = req.user as User;
+      const redirectUrlBase =
+        process.env.REDIRECT_URL_BASE || 'http://localhost:5173';
 
-    if (user) {
-      const redirectUrl = `${redirectUrlBase}/login?token=${user.access_token}&user=${encodeURIComponent(
-        JSON.stringify(user),
-      )}`;
+      if (user) {
+        const redirectUrl = `${redirectUrlBase}/login?token=${user.access_token}&user=${encodeURIComponent(
+          JSON.stringify(user),
+        )}`;
 
-      console.log('마지막 redirect URL:', redirectUrl);
+        console.log('마지막 redirect URL:', redirectUrl);
 
-      res.redirect(redirectUrl);
-    } else {
-      res.redirect('/');
-    }
+        res.redirect(redirectUrl);
+      } else {
+        res.redirect('/');
+      }
+    });
   },
 );
 

--- a/src/presentation/routers/auth/naverRouter.ts
+++ b/src/presentation/routers/auth/naverRouter.ts
@@ -22,21 +22,27 @@ naverRouter.get(
   '/callback',
   passport.authenticate('naver', { failureRedirect: '/' }),
   (req, res) => {
-    const user = req.user as User;
-    const redirectUrlBase =
-      process.env.REDIRECT_URL_BASE || 'http://localhost:5173';
+    req.session.regenerate((err) => {
+      if (err) {
+        console.error('세션 복구 오류:', err);
+        return res.redirect('/');
+      }
+      const user = req.user as User;
+      const redirectUrlBase =
+        process.env.REDIRECT_URL_BASE || 'http://localhost:5173';
 
-    if (user) {
-      const redirectUrl = `${redirectUrlBase}/login?token=${user.access_token}&user=${encodeURIComponent(
-        JSON.stringify(user),
-      )}`;
+      if (user) {
+        const redirectUrl = `${redirectUrlBase}/login?token=${user.access_token}&user=${encodeURIComponent(
+          JSON.stringify(user),
+        )}`;
 
-      console.log('마지막 redirect URL:', redirectUrl);
+        console.log('마지막 redirect URL:', redirectUrl);
 
-      res.redirect(redirectUrl);
-    } else {
-      res.redirect('/');
-    }
+        res.redirect(redirectUrl);
+      } else {
+        res.redirect('/');
+      }
+    });
   },
 );
 


### PR DESCRIPTION
A,B의 사용자가 각자 다른 기기에서 각자의 아이디로 로그인 시도.
A사용자가 A사용자의 기기에서 로그인을 하고 난 뒤
B 사용자가 B사용자의 기기에서 로그인을 시도했을때 A 사용자의 정보가 보임.

해당 현상을 수정하기 위해 로그인을 할 때 마다 새로운 세션을 생성하고  로그아웃을 할 때 세션을 삭제하여 독립적으로 유저 정보를 관리하고 동작하도록 수정 => 테스트 필요

